### PR TITLE
Fixed filepath argument value passed to preprocessor by jsCompiler. j…

### DIFF
--- a/lib/jsCompiler.js
+++ b/lib/jsCompiler.js
@@ -46,7 +46,7 @@ module.exports = function(app) {
       if (file === '.' || file === '..' || file === 'Thumbs.db' || fs.lstatSync(app.get('jsPath') + file).isDirectory()) {
         return;
       }
-      preprocessorModule.parse(app, file, (app.get('jsCompiledOutput') + (altdest ? altdest : '')), function(err, newJs) {
+      preprocessorModule.parse(app, file, (app.get('jsCompiledOutput') + (altdest ? altdest : file)), function(err, newJs) {
         var newFile;
         if (err) {
           console.error(((app.get('appName') || 'Roosevelt') + ' failed to parse ' + file + '. Please ensure that it is coded correctly.').red);


### PR DESCRIPTION
…sCompiler now passes the original filename, if altdest isn't specified via jsCompilerWhitelist or returned from wrench.