### PR TITLE
Fixed Lib Directory Symlink Custom Config

### DIFF
--- a/lib/sourceParams.js
+++ b/lib/sourceParams.js
@@ -47,7 +47,7 @@ module.exports = function(app) {
 
     // Utility lib
     libPath: params.libPath || pkg.rooseveltConfig.libPath || 'lib',
-    libPathNodeModulesSymlink: params.libPathNodeModulesSymlink || pkg.rooseveltConfig.libPathNodeModulesSymLink || 'lib',
+    libPathNodeModulesSymlink: params.libPathNodeModulesSymlink || pkg.rooseveltConfig.libPathNodeModulesSymlink || 'lib',
 
     // error pages
     error404: params.error404 || pkg.rooseveltConfig.error404 || '404.js',


### PR DESCRIPTION
User defined lib directory symlink name configuration fixed (No longer defaults to 'lib' when defined).