### PR TITLE
Adding Browserify to Roosevelt

### DIFF
--- a/lib/browserifyBundling.js
+++ b/lib/browserifyBundling.js
@@ -1,0 +1,41 @@
+// Handles Browserify bundling for static JavaScript files
+'use strict';
+
+var colors = require('colors'),
+    fs = require('fs-extra'),
+    browserify = require('browserify'),
+    appDir = require('./getAppDir'),
+    pkg = require(appDir + 'package.json');
+pkg.rooseveltConfig = pkg.rooseveltConfig || {};
+
+module.exports = function(app) {
+  var options = {
+    paths: ['statics/js/'],
+    entries: ['statics/js/main.js']
+  };
+
+  app.set('package', pkg);
+
+  // Sets bundled file name to be main.js if none is present in Roosevelt's configuration
+  if (!pkg.rooseveltConfig.browserifyFileName) {
+    pkg.rooseveltConfig.browserifyFileName = 'main.js';
+  }
+
+  // Checks if a dev.js file is present and the user is running in development mode
+  if (process.env.NODE_ENV === 'development' && fs.statSync('statics/js/dev.js')) {
+    options.entries.push('statics/js/dev.js');
+  }
+
+  // Begins Browserify bundling
+  browserify(options).bundle(function(err, jsCode) {
+    if (err) {
+      console.error(('The browserify step cannot be completed due to syntax errors in the source JavaScript\nError: ' + err.message).red);
+      throw err;
+    }
+    else {
+      // Ensures that the build directory exists and creates a bundled JavaScript file. If the directory structure does not exist, it is created.
+      fs.ensureDirSync('statics/.build/js');
+      fs.writeFileSync('statics/.build/js/' + pkg.rooseveltConfig.browserifyFileName, jsCode, 'utf8');
+    }
+  });
+};

--- a/package.json
+++ b/package.json
@@ -13,6 +13,7 @@
   "engineStrict": true,
   "dependencies": {
     "body-parser": "^1.0.0",
+    "browserify": "~13.1.0",
     "colors": "^1.0.0",
     "compression": "^1.0.0",
     "cookie-parser": "^1.3.0",
@@ -51,6 +52,6 @@
   "_from": "roosevelt@*",
   "gitHead": "",
   "scripts": {
-    "test": "jshint roosevelt.js defaultErrorPages/controllers/5xx.js defaultErrorPages/controllers/404.js defaultErrorPages/controllers/503.js lib/enableMultipart.js lib/getAppDir.js lib/jsCompiler.js lib/mapRoutes.js lib/preprocessCss.js lib/setExpressConfigs.js lib/sourceParams.js"
+    "test": "jshint roosevelt.js defaultErrorPages/controllers/5xx.js defaultErrorPages/controllers/404.js defaultErrorPages/controllers/503.js lib/enableMultipart.js lib/getAppDir.js lib/jsCompiler.js lib/mapRoutes.js lib/preprocessCss.js lib/setExpressConfigs.js lib/sourceParams.js lib/browserifyBundling.js"
   }
 }

--- a/roosevelt.js
+++ b/roosevelt.js
@@ -49,6 +49,9 @@ module.exports = function(params) {
   // activate css preprocessor
   require('./lib/preprocessCss')(app);
 
+  // activate browserify
+  require('./lib/browserifyBundling')(app, process);
+
   // activate js compiler
   require('./lib/jsCompiler')(app);
 


### PR DESCRIPTION
Takes `browserifyFileName` from Roosevelt config to name the bundled js file, otherwise the file is named `main.js`
