### PR TITLE
limit parameter

### DIFF
--- a/README.md
+++ b/README.md
@@ -223,7 +223,7 @@ App behavior parameters
   - Default: `2000` (2 seconds)
 - `shutdownTimeout`: Maximum amount of time in miliseconds given to Roosevelt to gracefully shut itself down when sent the kill signal.
   - Default: `30000` (30 seconds)
-
+  
 HTTPS parameters
 ---
 
@@ -246,6 +246,8 @@ HTTPS parameters
   - Default: `false`
 - `rejectUnauthorized`: Upon failing to authorize a user with supplied CA(s), reject their connection entirely.
   - Default: `false`
+- `limit`: Controls the maximum request body size with the [body-parser](https://www.npmjs.com/package/body-parser). If this is a number, then the value specifies the number of bytes; if it is a string, the value is passed to the [bytes](https://www.npmjs.com/package/bytes) library for parsing. 
+  - Default: `100kb` 
 
 MVC parameters
 ---

--- a/lib/setExpressConfigs.js
+++ b/lib/setExpressConfigs.js
@@ -52,9 +52,14 @@ module.exports = function(app) {
 
   // defines req.body by parsing http requests
   app.use(bodyParser.urlencoded({
-    extended: true
+    extended: true,
+    limit: params.limit
   }));
-  app.use(bodyParser.json());
+    
+  // when the HTTP request contains JSON data this parser is used
+  app.use(bodyParser.json({
+    limit: params.limit
+  }));
 
   // enables PUT and DELETE requests via <input type='hidden' name='_method' value='put'> and suchlike
   app.use(require('method-override')());

--- a/lib/sourceParams.js
+++ b/lib/sourceParams.js
@@ -47,7 +47,7 @@ module.exports = function(app) {
     ca: params.ca || pkg.rooseveltConfig.ca || null, // string or array of strings (file paths)
     requestCert: params.requestCert || pkg.rooseveltConfig.requestCert || false,
     rejectUnauthorized: params.rejectUnauthorized || pkg.rooseveltConfig.rejectUnauthorized || false,
-
+    limit: params.limit || pkg.rooseveltConfig.limit || '100kb',
     // mvc
     modelsPath: params.modelsPath || pkg.rooseveltConfig.modelsPath || 'mvc/models',
     modelsNodeModulesSymlink: params.modelsNodeModulesSymlink || pkg.rooseveltConfig.modelsNodeModulesSymlink || 'models',


### PR DESCRIPTION
Added support for the limit parameter allowing users to set the limit coming from the package.json. It is applied in the the express body parser and in the JSON parser. This limit is necessary when POSTing data greater than 100kb in size.