### PR TITLE
Fixed Roosevelt `stat`ing bad path causing it not to run (Closes #68)

### DIFF
--- a/lib/jsCompiler.js
+++ b/lib/jsCompiler.js
@@ -43,7 +43,8 @@ module.exports = function(app) {
       var split = file.split(':'),
           altdest = split[1];
       file = split[0];
-      if (file === '.' || file === '..' || file === 'Thumbs.db' || fs.lstatSync(file).isDirectory()) {
+      if (file === '.' || file === '..' || file === 'Thumbs.db' || fs.lstatSync(path.normalize(app.get('jsPath') + file)).isDirectory()
+) {
         return;
       }
       file = file.replace(app.get('jsPath'), '');


### PR DESCRIPTION
Using just the file without normalizing the jsPath and file name will cause Roosevelt to stat the wrong directory. This fixes that problem.

(Closes #68)