### PR TITLE
Check that html exists before running validator (Closes #106)

### DIFF
--- a/lib/htmlValidator.js
+++ b/lib/htmlValidator.js
@@ -54,7 +54,7 @@ module.exports = function(app) {
       // get the html for this specific render
       app.render(view, model, function(err, html) {
 
-        if (process.env.NODE_ENV === 'development' && !validatorDisabled && res.get(headerException) !== 'true' && !model[modelException]) {
+        if (process.env.NODE_ENV === 'development' && !validatorDisabled && res.get(headerException) !== 'true' && !model[modelException] && html) {
           // run HTML validator and display errors on page
           options.data = html;
 


### PR DESCRIPTION
Good find. We definitely don't need the validator obfuscating other errors.