### PR TITLE
Resolve app crashing if moved/renamed (Closes #44)

### DIFF
--- a/lib/checkFiles.js
+++ b/lib/checkFiles.js
@@ -24,4 +24,4 @@ module.exports = {
       return false;
     }
   }
-}
+};

--- a/lib/checkFiles.js
+++ b/lib/checkFiles.js
@@ -1,0 +1,27 @@
+// check existence of files and symlinks
+
+var fs = require('fs');
+
+module.exports = {
+  // Checks the existence of a file to replace deprecated fs.existsSync function
+  fileExists: function(path) {
+    try {
+      fs.accessSync(path);
+      return true;
+    }
+    catch (e) {
+      return false;
+    }
+  },
+
+  // Checks if symlink exists
+  symlinkExists: function(path) {
+    try {
+      fs.readlinkSync(path);
+      return true;
+    }
+    catch (e) {
+      return false;
+    }
+  }
+}

--- a/lib/htmlMinify.js
+++ b/lib/htmlMinify.js
@@ -1,3 +1,5 @@
+// html minifier
+
 var minifyHTML = require('express-minify-html');
 
 module.exports = function(app) {

--- a/lib/htmlValidator.js
+++ b/lib/htmlValidator.js
@@ -1,11 +1,7 @@
-var colors = require('colors'),
-    validator = require('html-validator'),
-    path = require('path');
+// html validator
 
-colors.setTheme({
-  warn: 'yellow',
-  error: 'red'
-});
+var validator = require('html-validator'),
+    path = require('path');
 
 module.exports = function(app) {
   var params = app.get('params'),
@@ -13,18 +9,15 @@ module.exports = function(app) {
       modelException = params.validatorExceptions.modelValue,
       options,
       i,
-
       errorArr,
       errorArrLength,
       errorLine,
       errorList,
       warningList,
-
       htmlArr,
       htmlArrLength,
       htmlLine,
       formattedHTML,
-
       errorPage = path.normalize(__dirname + '/../defaultErrorPages/views/validatorErrors'),
       validatorDisabled;
 

--- a/lib/jsBundler.js
+++ b/lib/jsBundler.js
@@ -4,7 +4,8 @@ require('colors');
 
 var browserify = require('browserify'),
     path = require('path'),
-    fse = require('fs-extra');
+    fse = require('fs-extra'),
+    checkFiles = require('./checkFiles');
 
 module.exports = function(app, callback) {
   var params = app.get('params'),
@@ -13,19 +14,19 @@ module.exports = function(app, callback) {
       promises = [];
 
   // make js directory if not present
-  if (!fse.existsSync(app.get('jsPath'))) {
+  if (!checkFiles.fileExists(app.get('jsPath'))) {
     fse.mkdirsSync(app.get('jsPath'));
     console.log(('📁  ' + (app.get('package').name || 'Roosevelt') + ' making new directory ' + path.normalize(app.get('jsPath').replace(app.get('appDir'), ''))).yellow);
   }
 
   // make js bundled output directory if not present
-  if (params.browserifyBundles.length && !fse.existsSync(params.bundledJsPath)) {
+  if (params.browserifyBundles.length && !checkFiles.fileExists(params.bundledJsPath)) {
     fse.mkdirsSync(params.bundledJsPath);
     console.log(('📁  ' + (app.get('package').name || 'Roosevelt') + ' making new directory ' + path.normalize(app.get('appDir') + params.bundledJsPath.replace(app.get('appDir'))), '').yellow);
   }
 
   // make js bundled output directory in build directory if not present
-  if (params.browserifyBundles.length && params.exposeBundles && !fse.existsSync(bundleBuildDir)) {
+  if (params.browserifyBundles.length && params.exposeBundles && !checkFiles.fileExists(bundleBuildDir)) {
     fse.mkdirsSync(bundleBuildDir);
     console.log(('📁  ' + (app.get('package').name || 'Roosevelt') + ' making new directory ' + path.normalize(bundleBuildDir), '').yellow);
   }

--- a/lib/jsCompiler.js
+++ b/lib/jsCompiler.js
@@ -5,7 +5,8 @@ require('colors');
 var fs = require('fs'),
     path = require('path'),
     fse = require('fs-extra'),
-    prequire = require('parent-require');
+    prequire = require('parent-require'),
+    checkFiles = require('./checkFiles');
 
 module.exports = function(app, callback) {
   var params = app.get('params'),
@@ -32,7 +33,7 @@ module.exports = function(app, callback) {
   }
 
   // make js compiled output directory if not present
-  if (params.jsCompiler && params.jsCompiler.nodeModule && !fs.existsSync(app.get('jsCompiledOutput'))) {
+  if (params.jsCompiler && params.jsCompiler.nodeModule && !checkFiles.fileExists(app.get('jsCompiledOutput'))) {
     fse.mkdirsSync(app.get('jsCompiledOutput'));
     console.log(('📁  ' + (app.get('package').name || 'Roosevelt') + ' making new directory ' + app.get('jsCompiledOutput').replace(app.get('appDir'), '')).yellow);
   }

--- a/lib/mapRoutes.js
+++ b/lib/mapRoutes.js
@@ -6,7 +6,8 @@ var fs = require('fs'),
     path = require('path'),
     fse = require('fs-extra'),
     //toobusy = require('toobusy'), // disabled because https://github.com/lloyd/node-toobusy/issues/45
-    os = require('os');
+    os = require('os'),
+    checkFiles = require('./checkFiles');
 
 module.exports = function(app) {
   var params = app.get('params'),
@@ -57,7 +58,7 @@ module.exports = function(app) {
   publicDir = path.normalize(params.publicFolder);
 
   // make public folder itself if it doesn't exist
-  if (!fs.existsSync(publicDir)) {
+  if (!checkFiles.fileExists(publicDir)) {
     fse.mkdirsSync(publicDir);
     console.log(('📁  ' + (app.get('appName') || 'Roosevelt') + ' making new directory ' + publicDir.replace(app.get('appDir'), '')).yellow);
   }
@@ -65,7 +66,7 @@ module.exports = function(app) {
   // make statics prefix folder if the setting is enabled
   if (params.staticsPrefix) {
     publicDir += path.normalize(params.staticsPrefix + '/');
-    if (!fs.existsSync(publicDir)) {
+    if (!checkFiles.fileExists(publicDir)) {
       fse.mkdirsSync(publicDir);
       console.log(('📁  ' + (app.get('appName') || 'Roosevelt') + ' making new directory ' + publicDir.replace(app.get('appDir'), '')).yellow);
     }
@@ -78,18 +79,19 @@ module.exports = function(app) {
         linkTarget = (appDir + publicDir + pubStatic[0].trim());
 
     // make static target folder if it hasn't yet been created
-    if (!fs.existsSync(staticTarget)) {
+    if (!checkFiles.fileExists(staticTarget)) {
       fse.mkdirsSync(staticTarget);
       console.log(('📁  ' + (app.get('appName') || 'Roosevelt') + ' making new directory ' + staticTarget.replace(app.get('appDir'), '')).yellow);
     }
 
     // make symlink if it doesn't yet exist
-    fs.access(linkTarget, function(err) {
-      if (err) {
-        fs.symlinkSync(staticTarget, linkTarget, 'junction');
-        console.log(('📁  ' + (app.get('appName') || 'Roosevelt') + ' making new symlink ').cyan + (linkTarget.replace(app.get('appDir'), '')).yellow + (' pointing to ').cyan + (staticTarget.replace(app.get('appDir'), '')).yellow);
+    if (!checkFiles.fileExists(linkTarget)) {
+      if (checkFiles.symlinkExists(linkTarget)) {
+        fs.unlinkSync(linkTarget);
       }
-    });
+      fs.symlinkSync(staticTarget, linkTarget);
+      console.log(('📁  ' + (app.get('appName') || 'Roosevelt') + ' making new symlink ').cyan + (linkTarget.replace(app.get('appDir'), '')).yellow + (' pointing to ').cyan + (staticTarget.replace(app.get('appDir'), '')).yellow);
+    }
   });
 
   // map statics for developer mode

--- a/lib/preprocessCss.js
+++ b/lib/preprocessCss.js
@@ -4,7 +4,8 @@ require('colors');
 
 var fs = require('fs'),
     fse = require('fs-extra'),
-    prequire = require('parent-require');
+    prequire = require('parent-require'),
+    checkFiles = require('./checkFiles');
 
 module.exports = function(app, callback) {
   var params = app.get('params'),
@@ -49,13 +50,13 @@ module.exports = function(app, callback) {
   }
 
   // make css directory if not present
-  if (!fs.existsSync(app.get('cssPath'))) {
+  if (!checkFiles.fileExists(app.get('cssPath'))) {
     fse.mkdirsSync(app.get('cssPath'));
     console.log(('📁  ' + (app.get('package').name || 'Roosevelt') + ' making new directory ' + app.get('cssPath').replace(app.get('appDir'), '')).yellow);
   }
 
   // make css compiled output directory if not present
-  if (params.cssCompiler && params.cssCompiler.nodeModule && !fs.existsSync(app.get('cssCompiledOutput'))) {
+  if (params.cssCompiler && params.cssCompiler.nodeModule && !checkFiles.fileExists(app.get('cssCompiledOutput'))) {
     fse.mkdirsSync(app.get('cssCompiledOutput'));
     console.log(('📁  ' + (app.get('package').name || 'Roosevelt') + ' making new directory ' + app.get('cssCompiledOutput').replace(app.get('appDir'), '')).yellow);
   }

--- a/lib/sourceParams.js
+++ b/lib/sourceParams.js
@@ -5,7 +5,7 @@ require('colors');
 var fs = require('fs'),
     path = require('path'),
     appDir = require('./getAppDir'),
-    pkg = require(appDir + 'package.json');
+    pkg = require(appDir + 'package.json'),
     checkFiles = require('./checkFiles');
 pkg.rooseveltConfig = pkg.rooseveltConfig || {};
 

--- a/lib/sourceParams.js
+++ b/lib/sourceParams.js
@@ -6,11 +6,13 @@ var fs = require('fs'),
     path = require('path'),
     appDir = require('./getAppDir'),
     pkg = require(appDir + 'package.json');
+    checkFiles = require('./checkFiles');
 pkg.rooseveltConfig = pkg.rooseveltConfig || {};
 
 module.exports = function(app) {
   var params = app.get('params'),
       modelsFolder,
+      relativeModelPath,
       libFolder,
       linkTarget;
 
@@ -162,19 +164,19 @@ module.exports = function(app) {
 
   // ensure 404 page exists
   params.error404 = app.get('controllersPath') + params.error404;
-  if (!fs.existsSync(params.error404)) {
+  if (!checkFiles.fileExists(params.error404)) {
     params.error404 = appDir + 'node_modules/roosevelt/defaultErrorPages/controllers/404.js';
   }
 
   // ensure 500 page exists
   params.error5xx = app.get('controllersPath') + params.error5xx;
-  if (!fs.existsSync(params.error5xx)) {
+  if (!checkFiles.fileExists(params.error5xx)) {
     params.error5xx = appDir + 'node_modules/roosevelt/defaultErrorPages/controllers/5xx.js';
   }
 
   // ensure 503 page exists
   params.error503 = app.get('controllersPath') + params.error503;
-  if (!fs.existsSync(params.error503)) {
+  if (!checkFiles.fileExists(params.error503)) {
     params.error503 = appDir + 'node_modules/roosevelt/defaultErrorPages/controllers/503.js';
   }
 
@@ -188,8 +190,12 @@ module.exports = function(app) {
     modelsFolder = appDir + params.modelsPath;
     linkTarget = appDir + 'node_modules/' + params.modelsNodeModulesSymlink;
 
-    if (!fs.existsSync(linkTarget) || !fs.readlinkSync(linkTarget)) {
-      fs.symlinkSync(modelsFolder, linkTarget, 'junction');
+    if (!checkFiles.fileExists(linkTarget)) {
+      // check for broken symlink
+      if (checkFiles.symlinkExists(linkTarget)) {
+        fs.unlinkSync(linkTarget);
+      }
+      fs.symlinkSync(modelsFolder, linkTarget);
       console.log(('📂  ' + (app.get('appName') || 'Roosevelt') + ' making new symlink ').cyan + (linkTarget.replace(app.get('appDir'), '')).yellow + (' pointing to ').cyan + (modelsFolder.replace(app.get('appDir'), '')).yellow);
     }
   }
@@ -197,10 +203,13 @@ module.exports = function(app) {
   // if utility lib dir exists, make a symlink to it in node_modules
   libFolder = appDir + params.libPath;
 
-  if (fileExists(libFolder) && params.libPathNodeModulesSymlink) {
+  if (checkFiles.fileExists(libFolder) && params.libPathNodeModulesSymlink) {
     linkTarget = appDir + 'node_modules/' + params.libPathNodeModulesSymlink;
 
-    if (!fileExists(linkTarget) || !fs.readlinkSync(linkTarget)) {
+    if (!checkFiles.fileExists(linkTarget)) {
+      if (checkFiles.symlinkExists(linkTarget)) {
+        fs.unlinkSync(linkTarget);
+      }
       fs.symlinkSync(libFolder, linkTarget, 'junction');
       console.log(('📂  ' + (app.get('appName') || 'Roosevelt') + ' making new symlink ').cyan + (linkTarget.replace(app.get('appDir'), '')).yellow + (' pointing to ').cyan + (libFolder.replace(app.get('appDir'), '')).yellow);
     }
@@ -214,15 +223,3 @@ module.exports = function(app) {
 
   return app;
 };
-
-// Inner Function
-// Checks the existence of a file to replace deprecated fs.existsSync function
-function fileExists(path) {
-  try {
-    fs.accessSync(path);
-    return true;
-  }
-  catch (e) {
-    return false;
-  }
-}

--- a/lib/sourceParams.js
+++ b/lib/sourceParams.js
@@ -12,7 +12,6 @@ pkg.rooseveltConfig = pkg.rooseveltConfig || {};
 module.exports = function(app) {
   var params = app.get('params'),
       modelsFolder,
-      relativeModelPath,
       libFolder,
       linkTarget;
 


### PR DESCRIPTION
In order to smooth out app operations after a move we need to properly detect broken symlinks and replace them with new ones:

Enter `checkFiles.js`, the heroic helper module which contains our functions to check both the existence of files and symlinks, allowing us to wipe away any broken symlinks and pave the way for new ones to be made. As a bonus all instances of `fs.existsSync` have been replaced with the already integrated `fileExists` function, and if (more like when) the fs module changes the file detection method we only need to update that one function to cover the whole app.

Also tossed in some OCD cleanup of other modules