### PR TITLE
bring back toobusy (closes #31)

### DIFF
--- a/README.md
+++ b/README.md
@@ -242,7 +242,7 @@ App behavior parameters
 - `multipart`: Settings to pass along to [formidable](https://github.com/felixge/node-formidable) using [formidable's API](https://github.com/felixge/node-formidable#api) for multipart form processing. Access files uploaded in your controllers by examining the `req.files` object. Roosevelt will remove any files uploaded to the `uploadDir` when the request ends automatically. To keep any, be sure to move them before the request ends. To disable multipart forms entirely, set this option to false.
   - Default: `{'multiples': true}`
 - `maxLagPerRequest`: Maximum amount of time in miliseconds a given request is allowed to take before being interrupted with a 503 error. (See [node-toobusy](https://github.com/STRML/node-toobusy))
-  - Default: `2000` (2 seconds)
+  - Default: `70` (70ms)
 - `shutdownTimeout`: Maximum amount of time in miliseconds given to Roosevelt to gracefully shut itself down when sent the kill signal.
   - Default: `30000` (30 seconds)
 - `bodyParserUrlencodedParams`: Supply parameters to [body-parser.urlencoded](https://github.com/expressjs/body-parser#bodyparserurlencodedoptions).

--- a/README.md
+++ b/README.md
@@ -241,7 +241,7 @@ App behavior parameters
   - Default: `{'requestHeader': 'Partial', 'modelValue': '_disableValidator'}`
 - `multipart`: Settings to pass along to [formidable](https://github.com/felixge/node-formidable) using [formidable's API](https://github.com/felixge/node-formidable#api) for multipart form processing. Access files uploaded in your controllers by examining the `req.files` object. Roosevelt will remove any files uploaded to the `uploadDir` when the request ends automatically. To keep any, be sure to move them before the request ends. To disable multipart forms entirely, set this option to false.
   - Default: `{'multiples': true}`
-- ~~`maxLagPerRequest`: Maximum amount of time in miliseconds a given request is allowed to take before being interrupted with a 503 error. (See [node-toobusy](https://github.com/lloyd/node-toobusy))~~ *([Temporarily disabled](https://github.com/lloyd/node-toobusy/issues/45))*
+- `maxLagPerRequest`: Maximum amount of time in miliseconds a given request is allowed to take before being interrupted with a 503 error. (See [node-toobusy](https://github.com/STRML/node-toobusy))
   - Default: `2000` (2 seconds)
 - `shutdownTimeout`: Maximum amount of time in miliseconds given to Roosevelt to gracefully shut itself down when sent the kill signal.
   - Default: `30000` (30 seconds)

--- a/lib/mapRoutes.js
+++ b/lib/mapRoutes.js
@@ -5,7 +5,7 @@ require('colors');
 var fs = require('fs'),
     path = require('path'),
     fse = require('fs-extra'),
-    //toobusy = require('toobusy'), // disabled because https://github.com/lloyd/node-toobusy/issues/45
+    toobusy = require('toobusy-js'),
     os = require('os'),
     checkFiles = require('./checkFiles');
 
@@ -18,10 +18,9 @@ module.exports = function(app) {
       ec = 0;
 
   // define maximum number of miliseconds to wait for a given request to finish
-  //toobusy.maxLag(params.maxLagPerRequest);
+  toobusy.maxLag(params.maxLagPerRequest);
 
   // serve 503 page if the process is too busy
-  /*
   app.use(function(req, res, next) {
     if (toobusy()) {
       require(params.error503)(app, req, res);
@@ -29,7 +28,7 @@ module.exports = function(app) {
     else {
       next();
     }
-  });*/
+  });
 
   // bind user-defined middleware which fires just before executing the controller if supplied
   if (params.onReqBeforeRoute && typeof params.onReqBeforeRoute === 'function') {

--- a/lib/sourceParams.js
+++ b/lib/sourceParams.js
@@ -39,7 +39,7 @@ module.exports = function(app) {
     htmlValidator: params.htmlValidator || pkg.rooseveltConfig.htmlValidator || {htmlValidator: 'http://html5.validator.nu', format: 'text', suppressWarnings: false},
     validatorExceptions: params.validatorExceptions || pkg.rooseveltConfig.validatorExceptions || {requestHeader: 'Partial', modelValue: '_disableValidator'},
     multipart: params.multipart || pkg.rooseveltConfig.multipart || {'multiples': true},
-    maxLagPerRequest: params.maxLagPerRequest || pkg.maxLagPerRequest || 2000,
+    maxLagPerRequest: params.maxLagPerRequest || pkg.maxLagPerRequest || 70,
     shutdownTimeout: params.shutdownTimeout || pkg.shutdownTimeout || 30000,
     bodyParserUrlencodedParams: params.bodyParserUrlencodedParams || pkg.rooseveltConfig.bodyParserUrlencodedParams || { extended: true },
     bodyParserJsonParams: params.bodyParserJsonParams || pkg.rooseveltConfig.bodyParserJsonParams || {},

--- a/package.json
+++ b/package.json
@@ -25,7 +25,8 @@
     "method-override": "^2.0.0",
     "morgan": "^1.0.0",
     "parent-require": "^1.0.0",
-    "serve-favicon": "^2.3.0"
+    "serve-favicon": "^2.3.0",
+    "toobusy-js": "^0.5.1"
   },
   "devDependencies": {
     "eslint": "^3.5.0"


### PR DESCRIPTION
toobusy has been broken for a long time now due to its lack of maintenance, but now we have this very handy fork of it which rewrote the feature in JS!

That can be found here: https://github.com/STRML/node-toobusy

The API is exactly the same, so I was able to reuse the old code from the original implementation, I only changed the default maxLag setting to the suggested default of 70.

I tested that we hit the 503 by creating a slow route (Found in their readme) and trying to load the slow route and a normal route at the same time.