### PR TITLE
Bring in local HTML validation service (closes #107)

### DIFF
--- a/README.md
+++ b/README.md
@@ -235,7 +235,7 @@ App behavior parameters
 - `enableValidator`: Enables or disables the built-in HTML validator in dev mode.
   - Default: `false`
 - `htmlValidator`: Params to send to [html-validator](https://github.com/zrrrzzt/html-validator#usage) (if `enableValidator` is set to true). When `suppressWarnings` is set to true validation warnings will be hidden and only errors will be shown.
-  - Default:  `{validator: 'http://html5.validator.nu', format: 'text', suppressWarnings: false}`
+  - Default:  `{port: '8888', format: 'text', suppressWarnings: false}`
   - Can be disabled for individual requests by sending the request header `Partial` with the value set to `true` or by passing `_disableValidator` to the model and setting it to `true`.
 - `validatorExceptions`: Use this to customize the name of the request header or model value that is used to disable the HTML validator.
   - Default: `{'requestHeader': 'Partial', 'modelValue': '_disableValidator'}`

--- a/lib/htmlValidator.js
+++ b/lib/htmlValidator.js
@@ -1,10 +1,13 @@
 // html validator
 
 var validator = require('html-validator'),
-    path = require('path');
+    path = require('path'),
+    spawn = require('child_process').spawn,
+    vnu = require('vnu-jar');
 
 module.exports = function(app) {
   var params = app.get('params'),
+      validatorProcess,
       headerException = params.validatorExceptions.requestHeader,
       modelException = params.validatorExceptions.modelValue,
       options,
@@ -24,14 +27,22 @@ module.exports = function(app) {
   if (!params.enableValidator) {
     validatorDisabled = true;
   }
-
-  if (!params.htmlValidator) {
-    options = {
-      format: 'text'
-    };
-  }
   else {
-    options = params.htmlValidator;
+    if (!params.htmlValidator) {
+      options = {
+        validator: 'http://localhost:8888',
+        format: 'text'
+      };
+    }
+    else {
+      params.htmlValidator.validator = 'http://localhost:' + (params.htmlValidator.port ? params.htmlValidator.port : '8888');
+      options = params.htmlValidator;
+    }
+
+    // spawn validator child process
+    validatorProcess = spawn(
+      'java', ['-cp', vnu, 'nu.validator.servlet.Main', params.htmlValidator.port ? params.htmlValidator.port : '8888']
+    );
   }
 
   app.use(function(req, res, next) {

--- a/lib/htmlValidator.js
+++ b/lib/htmlValidator.js
@@ -7,7 +7,6 @@ var validator = require('html-validator'),
 
 module.exports = function(app) {
   var params = app.get('params'),
-      validatorProcess,
       headerException = params.validatorExceptions.requestHeader,
       modelException = params.validatorExceptions.modelValue,
       options,
@@ -40,7 +39,7 @@ module.exports = function(app) {
     }
 
     // spawn validator child process
-    validatorProcess = spawn(
+    spawn(
       'java', ['-cp', vnu, 'nu.validator.servlet.Main', params.htmlValidator.port ? params.htmlValidator.port : '8888']
     );
   }

--- a/lib/sourceParams.js
+++ b/lib/sourceParams.js
@@ -36,7 +36,7 @@ module.exports = function(app) {
     disableLogger: params.disableLogger || pkg.rooseveltConfig.disableLogger || false,
     noMinify: params.noMinify || pkg.rooseveltConfig.noMinify || false,
     enableValidator: params.enableValidator || pkg.rooseveltConfig.enableValidator || false,
-    htmlValidator: params.htmlValidator || pkg.rooseveltConfig.htmlValidator || {htmlValidator: 'http://html5.validator.nu', format: 'text', suppressWarnings: false},
+    htmlValidator: params.htmlValidator || pkg.rooseveltConfig.htmlValidator || {port: '8888', format: 'text', suppressWarnings: false},
     validatorExceptions: params.validatorExceptions || pkg.rooseveltConfig.validatorExceptions || {requestHeader: 'Partial', modelValue: '_disableValidator'},
     multipart: params.multipart || pkg.rooseveltConfig.multipart || {'multiples': true},
     maxLagPerRequest: params.maxLagPerRequest || pkg.maxLagPerRequest || 70,

--- a/package.json
+++ b/package.json
@@ -29,7 +29,8 @@
     "toobusy-js": "^0.5.1"
   },
   "devDependencies": {
-    "eslint": "^3.5.0"
+    "eslint": "^3.5.0",
+    "vnu-jar": "17.3.0"
   },
   "repository": {
     "type": "git",


### PR DESCRIPTION
No more relying on an internet service for HTML validation. We've got it covered right here thanks to the official [Nu HTML Checker](https://github.com/validator/validator).

We spawn this as a child process and use the same validation API we're used to but without having to rely on an external internet service!